### PR TITLE
Add simple beam deflection calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,6 @@ The landscape responsive breakpoint will be applied when the screen width is gre
 And then this will be the only point at which Flexisel changes.
 
 [View Demo](http://9bitstudios.github.com/flexisel/) | [Buy Author a Coffee](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NNCJ79B2W6MUL)
+
+## Deflection Calculator
+A simple tool to estimate the maximum deflection of a simply supported beam with a center load is provided in [deflection-calculator.html](deflection-calculator.html).

--- a/deflection-calculator.html
+++ b/deflection-calculator.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Deflection Calculator</title>
+    <link rel="stylesheet" href="css/style.css">
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .container { max-width: 600px; margin: auto; }
+        label { display: block; margin-top: 10px; }
+        input[type="number"] { width: 100%; padding: 8px; box-sizing: border-box; }
+        #result { margin-top: 20px; font-weight: bold; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Deflection Calculator</h1>
+    <p>Calculate the maximum deflection of a simply supported beam with a center load.</p>
+    <label for="load">Load P (N):</label>
+    <input type="number" id="load" />
+    <label for="length">Length L (m):</label>
+    <input type="number" id="length" />
+    <label for="elasticity">Elastic Modulus E (Pa):</label>
+    <input type="number" id="elasticity" />
+    <label for="inertia">Moment of Inertia I (m<sup>4</sup>):</label>
+    <input type="number" id="inertia" />
+    <button id="calculate">Calculate</button>
+    <div id="result"></div>
+</div>
+<script src="js/deflection.js"></script>
+</body>
+</html>

--- a/js/deflection.js
+++ b/js/deflection.js
@@ -1,0 +1,19 @@
+(function() {
+    function calculateDeflection(P, L, E, I) {
+        return (P * Math.pow(L, 3)) / (48 * E * I);
+    }
+
+    document.getElementById('calculate').addEventListener('click', function() {
+        var load = parseFloat(document.getElementById('load').value);
+        var length = parseFloat(document.getElementById('length').value);
+        var elasticity = parseFloat(document.getElementById('elasticity').value);
+        var inertia = parseFloat(document.getElementById('inertia').value);
+
+        if (isNaN(load) || isNaN(length) || isNaN(elasticity) || isNaN(inertia)) {
+            document.getElementById('result').textContent = 'Please enter valid numbers for all fields.';
+            return;
+        }
+        var deflection = calculateDeflection(load, length, elasticity, inertia);
+        document.getElementById('result').textContent = 'Maximum deflection: ' + deflection.toExponential(3) + ' meters';
+    });
+})();


### PR DESCRIPTION
## Summary
- add a small HTML/JS deflection calculator for a simply supported beam
- document the new page in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c3b9c25e0833281688acb7d04189b