### PR TITLE
Add JSON schema validation for structural data

### DIFF
--- a/building-structure/PARAMETERS.md
+++ b/building-structure/PARAMETERS.md
@@ -1,0 +1,21 @@
+# Parameter Reference
+
+All coordinates are in **inches** within a right-handed XYZ system.
+
+| Parameter | Type | Units | Description |
+|-----------|------|-------|-------------|
+| `start_point`, `end_point` | string | n/a | Reference IDs from `points.yml` defining member endpoints |
+| `size` | string | varies | Nominal member size (e.g., steel shape, lumber dimensions) |
+| `loads.gravity_lb` | number | lb | Applied gravity load at the member |
+| `loads.uplift_lb` | number | lb | Uplift load at the member |
+| `loads.lateral_ew_lb` | number | lb | Lateral load in east-west direction |
+| `loads.lateral_ns_lb` | number | lb | Lateral load in north-south direction |
+| `loads.uniform_plf` | number | plf | Uniform line load along the member |
+| `loads.point_lb` | number | lb | Concentrated load at connection points |
+| `base_plate.size` | string | in | Base plate width × depth × thickness |
+| `base_plate.edge_distance_in` | object | in | Edge distance from slab edges by direction |
+| `supports` | array[string] | n/a | IDs of members or walls providing support |
+| `connected_members` | array[string] | n/a | IDs of members directly connected |
+| `spacing_in` | number | in | Center-to-center spacing for repeated members |
+| `count` | integer | n/a | Number of repeated members in a set |
+| `connection_detail` | string | n/a | Description of how members are connected |

--- a/building-structure/README.md
+++ b/building-structure/README.md
@@ -1,0 +1,32 @@
+# Structural Design Data
+
+This directory stores a simplified dataset for the example building using YAML files. All coordinates are defined in `points.yml` and referenced by ID from each member file so that shared locations only need to be updated once.
+
+## Files
+
+- `points.yml` – master list of coordinate points.
+- `hss_columns.yml` – hollow structural section columns.
+- `w_beams.yml` – W-flange and LVL beams between columns.
+- `lvl_members.yml` – alternative LVL framing members.
+- `ridge_and_walls.yml` – ridge beam and load-bearing walls.
+- `rafter_sets.yml` – rafter series defined by spacing and count.
+- `roof_sections.yml` – roof sections with area and load path notes.
+- `PARAMETERS.md` – dictionary of parameter names, types and units.
+- `structural_layout.html` – visual layout based on the same data.
+
+### Validation
+
+JSON Schema files live in `schemas/` and can be used to ensure the YAML files
+are well-formed. From the repository root run:
+
+```bash
+python validate.py
+```
+
+to validate `points.yml` and `hss_columns.yml` against their schemas.
+
+### Report script
+
+Run `python report.py` from the repository root to view a summary of members with derived lengths or heights computed from point coordinates.
+
+The schema follows a consistent set of parameters (see `PARAMETERS.md`) so different member types share common field names where applicable.

--- a/building-structure/hss_columns.yml
+++ b/building-structure/hss_columns.yml
@@ -1,0 +1,157 @@
+# Hollow Structural Section columns
+columns:
+  - id: B1
+    start_point: B1_base
+    end_point: B1_top
+    size: 4x4x3/8
+    loads:
+      gravity_lb: 3950
+      uplift_lb: 280
+      lateral_ew_lb: 850
+      lateral_ns_lb: 1120
+    base_plate:
+      size: 8x8x1/2
+      edge_distance_in:
+        north: 5
+        east: 5
+    connected_members: [WF_B1_B2, LVL_Alt_1]
+  - id: B2
+    start_point: B2_base
+    end_point: B2_top
+    size: 4x4x3/8
+    loads:
+      gravity_lb: 4200
+      uplift_lb: 320
+      lateral_ew_lb: 920
+      lateral_ns_lb: 1080
+    base_plate:
+      size: 8x8x1/2
+      edge_distance_in:
+        north: 5
+    connected_members: [WF_B1_B2, WF_B2_B3, LVL_Alt_2]
+  - id: B3
+    start_point: B3_base
+    end_point: B3_top
+    size: 4x4x3/8
+    loads:
+      gravity_lb: 5850
+      uplift_lb: 380
+      lateral_ew_lb: 1240
+      lateral_ns_lb: 950
+    base_plate:
+      size: 8x8x1/2
+      edge_distance_in:
+        north: 5
+    connected_members: [WF_B2_B3, WF_B3_B4]
+  - id: B4
+    start_point: B4_base
+    end_point: B4_top
+    size: 4x4x3/8
+    loads:
+      gravity_lb: 7280
+      uplift_lb: 420
+      lateral_ew_lb: 1480
+      lateral_ns_lb: 880
+    base_plate:
+      size: 8x8x1/2
+      edge_distance_in:
+        north: 5
+    connected_members: [WF_B3_B4, WF_B4_B5]
+  - id: B5
+    start_point: B5_base
+    end_point: B5_top
+    size: 3.5x3.5x1/4
+    loads:
+      gravity_lb: 6950
+      uplift_lb: 480
+      lateral_ew_lb: 1640
+      lateral_ns_lb: 820
+    base_plate:
+      size: 8x8x1/2
+      edge_distance_in:
+        north: 5
+    connected_members: [WF_B4_B5, WF_B5_B6]
+  - id: B6
+    start_point: B6_base
+    end_point: B6_top
+    size: 4x4x3/8
+    loads:
+      gravity_lb: 5200
+      uplift_lb: 1200
+      lateral_ew_lb: 1640
+      lateral_ns_lb: 1850
+    base_plate:
+      size: 8x10x1/2
+      edge_distance_in:
+        north: 5
+        west: 5
+    connected_members: [WF_B5_B6, WF_B6_B7]
+  - id: B7
+    start_point: B7_base
+    end_point: B7_top
+    size: 3.5x3.5x1/4
+    loads:
+      gravity_lb: 2450
+      uplift_lb: 520
+      lateral_ns_lb: 1680
+    base_plate:
+      size: 6x8x1/2
+      edge_distance_in:
+        west: 5
+    connected_members: [WF_B6_B7, WF_B7_B8]
+  - id: B8
+    start_point: B8_base
+    end_point: B8_top
+    size: 4x4x3/8
+    loads:
+      gravity_lb: 12800
+      uplift_lb: 680
+      lateral_ns_lb: 1950
+    base_plate:
+      size: 8x8x1/2
+      edge_distance_in:
+        west: 5
+    connected_members: [WF_B7_B8, Ridge_Master]
+  - id: B9
+    start_point: B9_base
+    end_point: B9_top
+    size: 4x4x3/8
+    loads:
+      gravity_lb: 4850
+      uplift_lb: 340
+      lateral_ew_lb: 1420
+      lateral_ns_lb: 950
+    base_plate:
+      size: 8x8x1/2
+      edge_distance_in:
+        south: 5
+        east: 5
+    connected_members: [WF_B9_B10]
+  - id: B10
+    start_point: B10_base
+    end_point: B10_top
+    size: 4x4x3/8
+    loads:
+      gravity_lb: 5100
+      uplift_lb: 380
+      lateral_ew_lb: 1350
+      lateral_ns_lb: 820
+    base_plate:
+      size: 8x8x1/2
+      edge_distance_in:
+        east: 5
+    connected_members: [WF_B9_B10, WF_B10_B11]
+  - id: B11
+    start_point: B11_base
+    end_point: B11_top
+    size: 4x4x3/8
+    loads:
+      gravity_lb: 4720
+      uplift_lb: 350
+      lateral_ew_lb: 1280
+      lateral_ns_lb: 780
+    base_plate:
+      size: 8x8x1/2
+      edge_distance_in:
+        east: 5
+    connected_members: [WF_B10_B11]

--- a/building-structure/lvl_members.yml
+++ b/building-structure/lvl_members.yml
@@ -1,0 +1,16 @@
+# Laminated veneer lumber members
+lvl_members:
+  - id: LVL_Alt_1
+    start_point: B1_top
+    end_point: lvl_alt1_end
+    size: "2-ply 1.75x11.875"
+    loads:
+      uniform_plf: 380
+    connection_detail: "Saddle at B1, continuous span"
+  - id: LVL_Alt_2
+    start_point: B2_top
+    end_point: lvl_alt2_end
+    size: "2-ply 1.75x11.875"
+    loads:
+      uniform_plf: 380
+    connection_detail: "Saddle at B2, continuous span"

--- a/building-structure/points.yml
+++ b/building-structure/points.yml
@@ -1,0 +1,34 @@
+# Global coordinate points for structural elements
+points:
+  B1_base: {x: 0, y: 583, z: 0}
+  B1_top: {x: 0, y: 583, z: 144}
+  B2_base: {x: 0, y: 446, z: 0}
+  B2_top: {x: 0, y: 446, z: 144}
+  B3_base: {x: 0, y: 309, z: 0}
+  B3_top: {x: 0, y: 309, z: 144}
+  B4_base: {x: 0, y: 172, z: 0}
+  B4_top: {x: 0, y: 172, z: 144}
+  B5_base: {x: 0, y: 35, z: 0}
+  B5_top: {x: 0, y: 35, z: 144}
+  B6_base: {x: 0, y: 0, z: 0}
+  B6_top: {x: 0, y: 0, z: 144}
+  B7_base: {x: 91, y: 0, z: 0}
+  B7_top: {x: 91, y: 0, z: 144}
+  B8_base: {x: 204, y: 0, z: 0}
+  B8_top: {x: 204, y: 0, z: 144}
+  B9_base: {x: 389, y: 42, z: 0}
+  B9_top: {x: 389, y: 42, z: 144}
+  B10_base: {x: 389, y: 132, z: 0}
+  B10_top: {x: 389, y: 132, z: 144}
+  B11_base: {x: 389, y: 217, z: 0}
+  B11_top: {x: 389, y: 217, z: 144}
+  ridge_start: {x: 204, y: 0, z: 157}
+  ridge_end: {x: 580, y: 180, z: 157}
+  wall_ridge_start: {x: 0, y: 400, z: 154}
+  wall_ridge_end: {x: 580, y: 400, z: 154}
+  wall_master_east_start: {x: 580, y: 0, z: 144}
+  wall_master_east_end: {x: 580, y: 350, z: 144}
+  wall_south_start: {x: 204, y: 350, z: 144}
+  wall_south_end: {x: 580, y: 350, z: 144}
+  lvl_alt1_end: {x: 150, y: 514, z: 154}
+  lvl_alt2_end: {x: 150, y: 446, z: 154}

--- a/building-structure/rafter_sets.yml
+++ b/building-structure/rafter_sets.yml
@@ -1,0 +1,38 @@
+# Rafter series definitions
+rafter_sets:
+  - id: R169
+    start_member: Ridge_Master
+    end_member: WF_B4_B5
+    size: 2x12
+    spacing_in: 16
+    count: 42
+    loads:
+      point_lb: 580
+    connection_detail: "Top flange hanger to LUS210"
+  - id: R77
+    start_member: LB_Wall_Ridge
+    end_member: WF_B2_B3
+    size: 2x8
+    spacing_in: 16
+    count: 18
+    loads:
+      point_lb: 265
+    connection_detail: "Bearing on ridge wall to LUS26"
+  - id: R269
+    start_member: Ridge_Master
+    end_member: WF_B9_B10
+    size: 2x14
+    spacing_in: 24
+    count: 12
+    loads:
+      point_lb: 926
+    connection_detail: "Top flange hanger to ridge beam"
+  - id: Alt_R
+    start_member: LVL_Alt_1
+    end_member: LVL_Alt_2
+    size: 2x8
+    spacing_in: 16
+    count: 8
+    loads:
+      point_lb: 400
+    connection_detail: "LUS26 hangers to LVLs"

--- a/building-structure/ridge_and_walls.yml
+++ b/building-structure/ridge_and_walls.yml
@@ -1,0 +1,32 @@
+# Ridge beam and load-bearing walls
+components:
+  - id: Ridge_Master
+    type: ridge_beam
+    start_point: ridge_start
+    end_point: ridge_end
+    size: W14x34
+    loads:
+      uniform_plf: 895
+    supports: [B8_top, LB_Wall_Master_East]
+    connection_detail: "Knife plate connections"
+  - id: LB_Wall_Ridge
+    type: load_bearing_wall
+    start_point: wall_ridge_start
+    end_point: wall_ridge_end
+    framing: "2x6 studs 16 o.c."
+    foundation: continuous
+    notes: "Built-up posts at load points"
+  - id: LB_Wall_Master_East
+    type: load_bearing_wall
+    start_point: wall_master_east_start
+    end_point: wall_master_east_end
+    framing: "2x6 studs 16 o.c."
+    foundation: continuous
+    notes: "Ridge beam support post"
+  - id: LB_Wall_South
+    type: load_bearing_wall
+    start_point: wall_south_start
+    end_point: wall_south_end
+    framing: "2x6 studs 16 o.c."
+    foundation: continuous
+    notes: "Standard wall framing"

--- a/building-structure/roof_sections.yml
+++ b/building-structure/roof_sections.yml
@@ -1,0 +1,72 @@
+# Roof section data
+sections:
+  - id: Master-North-West
+    roof_system: Master/West Roof
+    description: North of ridge beam, B5-B6 span
+    supporting_structure: Ridge beam to north W-flange B5-B6
+    area_sf: 240
+    rafter_length_ft: 16.9
+    load_path: "Ridge beam -> North W-flange -> HSS B5, B6"
+  - id: Master-North-Central
+    roof_system: Master/West Roof
+    description: North of ridge beam, B4-B5 span
+    supporting_structure: Ridge beam to north W-flange B4-B5
+    area_sf: 320
+    rafter_length_ft: 16.9
+    load_path: "Ridge beam -> North W-flange -> HSS B4, B5"
+  - id: Master-North-Mixed
+    roof_system: Master/West Roof
+    description: North of ridge beam, B3-B4 span
+    supporting_structure: Ridge beam to north W-flange B3-B4
+    area_sf: 320
+    rafter_length_ft: 7.7/16.9
+    load_path: "Ridge beam -> North W-flange -> HSS B3, B4"
+  - id: Master-South
+    roof_system: Master/West Roof
+    description: South of ridge beam
+    supporting_structure: Ridge beam to south load bearing wall
+    area_sf: 580
+    rafter_length_ft: 15.4
+    load_path: "Ridge beam -> Load bearing wall"
+  - id: Bedrooms-North-East
+    roof_system: Bedrooms/East Roof
+    description: North of ridge wall, B2-B3 span
+    supporting_structure: Ridge wall to north W-flange B2-B3
+    area_sf: 180
+    rafter_length_ft: 7.7
+    load_path: "Ridge wall -> North W-flange -> HSS B2, B3"
+  - id: Bedrooms-Alt-Bay
+    roof_system: Bedrooms/East Roof
+    description: Alternative LVL framing B1-B2
+    supporting_structure: LVL members spanning over HSS columns
+    area_sf: 140
+    rafter_length_ft: 11.5
+    load_path: "LVL spans -> HSS B1 & B2"
+  - id: Bedrooms-South
+    roof_system: Bedrooms/East Roof
+    description: South of ridge wall
+    supporting_structure: Ridge wall to south load bearing wall
+    area_sf: 420
+    rafter_length_ft: 24.2
+    load_path: "Between load bearing walls"
+  - id: Clearstory-South
+    roof_system: Bedrooms/East Roof
+    description: Above clearstory glass B9-B11
+    supporting_structure: Clearstory beams to ridge beam
+    area_sf: 180
+    rafter_length_ft: 26.9
+    load_path: "B9-B11 beams -> Ridge beam"
+  - id: West-Overhang
+    roof_system: Both roofs
+    description: West overhang from B6-B7-B8
+    supporting_structure: Cantilevered from west beams
+    area_sf: 220
+    rafter_length_ft: "outriggers"
+    load_path: "West W-flanges"
+  - id: North-Overhang
+    roof_system: Both roofs
+    description: North overhang from all north beams
+    supporting_structure: Cantilevered from north beams
+    area_sf: 380
+    rafter_length_ft: "outriggers"
+    load_path: "North W-flanges"

--- a/building-structure/schemas/hss_columns.schema.json
+++ b/building-structure/schemas/hss_columns.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["columns"],
+  "properties": {
+    "columns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "start_point", "end_point", "size", "loads", "base_plate"],
+        "properties": {
+          "id": {"type": "string"},
+          "start_point": {"type": "string"},
+          "end_point": {"type": "string"},
+          "size": {"type": "string"},
+          "loads": {
+            "type": "object",
+            "properties": {
+              "gravity_lb": {"type": "number"},
+              "uplift_lb": {"type": "number"},
+              "lateral_ew_lb": {"type": "number"},
+              "lateral_ns_lb": {"type": "number"}
+            },
+            "additionalProperties": false
+          },
+          "base_plate": {
+            "type": "object",
+            "required": ["size", "edge_distance_in"],
+            "properties": {
+              "size": {"type": "string"},
+              "edge_distance_in": {
+                "type": "object",
+                "additionalProperties": {"type": "number"}
+              }
+            },
+            "additionalProperties": false
+          },
+          "connected_members": {
+            "type": "array",
+            "items": {"type": "string"}
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/building-structure/schemas/points.schema.json
+++ b/building-structure/schemas/points.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["points"],
+  "properties": {
+    "points": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["x", "y", "z"],
+        "properties": {
+          "x": {"type": "number"},
+          "y": {"type": "number"},
+          "z": {"type": "number"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/building-structure/structural_layout.html
+++ b/building-structure/structural_layout.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Roof Structure Layout</title>
+<style>
+body {font-family: Arial, sans-serif; margin:20px;background-color:#f5f5f5;}
+.container {max-width:1200px;margin:0 auto;background:white;padding:20px;border-radius:8px;box-shadow:0 2px 10px rgba(0,0,0,0.1);}
+.diagram {width:100%;height:800px;border:2px solid #333;position:relative;background:linear-gradient(to right,#f9f9f9 0%,#f9f9f9 100%);overflow:hidden;}
+.column {position:absolute;width:12px;height:12px;background-color:#e74c3c;border:2px solid #c0392b;border-radius:50%;transform:translate(-50%,-50%);}
+.column-label {position:absolute;font-size:10px;font-weight:bold;color:#2c3e50;transform:translate(-50%,-150%);background:rgba(255,255,255,0.9);padding:2px 4px;border-radius:3px;}
+.beam {position:absolute;height:3px;background-color:#3498db;border-radius:1px;}
+.beam-label {position:absolute;font-size:8px;color:#2980b9;transform:translate(-50%,-200%);background:rgba(255,255,255,0.8);padding:1px 3px;border-radius:2px;}
+.ridge-beam {position:absolute;height:4px;background-color:#9b59b6;border-radius:2px;}
+.load-bearing-wall {position:absolute;height:6px;background-color:#34495e;border-radius:1px;}
+.rafter {position:absolute;height:1px;background-color:#95a5a6;opacity:0.7;}
+.legend {margin-top:20px;display:flex;flex-wrap:wrap;gap:20px;}
+.legend-item {display:flex;align-items:center;gap:8px;}
+.legend-color {width:20px;height:12px;border-radius:2px;}
+.coordinates {margin-top:20px;display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px;font-size:12px;}
+.coord-item {background:#ecf0f1;padding:8px;border-radius:4px;}
+</style>
+</head>
+<body>
+<div class="container">
+<h1>Corrected Roof Structure Layout</h1>
+<div class="diagram" id="diagram"></div>
+<div class="legend">
+<div class="legend-item"><div class="legend-color" style="background-color:#e74c3c;border-radius:50%;"></div><span>HSS Columns</span></div>
+<div class="legend-item"><div class="legend-color" style="background-color:#3498db;"></div><span>W-Flange Beams</span></div>
+<div class="legend-item"><div class="legend-color" style="background-color:#9b59b6;"></div><span>Ridge Beam</span></div>
+<div class="legend-item"><div class="legend-color" style="background-color:#34495e;"></div><span>Load Bearing Walls</span></div>
+<div class="legend-item"><div class="legend-color" style="background-color:#95a5a6;"></div><span>Rafters (Sample)</span></div>
+</div>
+<div class="coordinates">
+<div class="coord-item"><strong>B1:</strong> (0", 583") - Northeast corner</div>
+<div class="coord-item"><strong>B2:</strong> (0", 446") - North wall</div>
+<div class="coord-item"><strong>B3:</strong> (0", 309") - North wall</div>
+<div class="coord-item"><strong>B4:</strong> (0", 172") - North wall</div>
+<div class="coord-item"><strong>B5:</strong> (0", 35") - North wall</div>
+<div class="coord-item"><strong>B6:</strong> (0", 0") - Northwest corner</div>
+<div class="coord-item"><strong>B7:</strong> (91", 0") - West wall</div>
+<div class="coord-item"><strong>B8:</strong> (204", 0") - West wall</div>
+<div class="coord-item"><strong>B9:</strong> (389", 42") - South wall</div>
+<div class="coord-item"><strong>B10:</strong> (389", 132") - South wall</div>
+<div class="coord-item"><strong>B11:</strong> (389", 217") - South wall</div>
+</div>
+<h2>Beam Specifications</h2>
+<div class="coordinates">
+<div class="coord-item"><strong>B1-B2:</strong> 11'5" span (Alternative framing)</div>
+<div class="coord-item"><strong>B2-B3:</strong> 11'5" span (7.7' rafters)</div>
+<div class="coord-item"><strong>B3-B4:</strong> 11'5" span (Mixed 7.7' & 16.9' rafters)</div>
+<div class="coord-item"><strong>B4-B5:</strong> 11'5" span (16.9' rafters)</div>
+<div class="coord-item"><strong>B5-B6:</strong> 2'11" span (16.9' rafters)</div>
+<div class="coord-item"><strong>B6-B7:</strong> 7'8" span (Curtain wall + overhang)</div>
+<div class="coord-item"><strong>B7-B8:</strong> 9'4" span (Curtain wall + overhang)</div>
+<div class="coord-item"><strong>B9-B10:</strong> 7'6" span (26.9' rafters to ridge)</div>
+<div class="coord-item"><strong>B10-B11:</strong> 7'1" span (26.9' rafters to ridge)</div>
+</div>
+</div>
+<script>
+const columns=[{id:'B1',x:50,y:750},{id:'B2',x:50,y:610},{id:'B3',x:50,y:470},{id:'B4',x:50,y:330},{id:'B5',x:50,y:190},{id:'B6',x:50,y:50},{id:'B7',x:140,y:50},{id:'B8',x:250,y:50},{id:'B9',x:470,y:90},{id:'B10',x:470,y:230},{id:'B11',x:470,y:320}];
+const beams=[{start:'B1',end:'B2',label:"B1-B2 (11'5")"},{start:'B2',end:'B3',label:"B2-B3 (11'5")"},{start:'B3',end:'B4',label:"B3-B4 (11'5")"},{start:'B4',end:'B5',label:"B4-B5 (11'5")"},{start:'B5',end:'B6',label:"B5-B6 (2'11")"},{start:'B6',end:'B7',label:"B6-B7 (7'8")"},{start:'B7',end:'B8',label:"B7-B8 (9'4")"},{start:'B9',end:'B10',label:"B9-B10 (7'6")"},{start:'B10',end:'B11',label:"B10-B11 (7'1")"}];
+const diagram=document.getElementById('diagram');
+columns.forEach(c=>{const el=document.createElement('div');el.className='column';el.style.left=c.x+'px';el.style.top=c.y+'px';diagram.appendChild(el);const lab=document.createElement('div');lab.className='column-label';lab.textContent=c.id;lab.style.left=c.x+'px';lab.style.top=c.y+'px';diagram.appendChild(lab);});
+beams.forEach(b=>{const s=columns.find(c=>c.id===b.start);const e=columns.find(c=>c.id===b.end);const el=document.createElement('div');el.className='beam';const dx=e.x-s.x;const dy=e.y-s.y;const len=Math.sqrt(dx*dx+dy*dy);const ang=Math.atan2(dy,dx)*180/Math.PI;el.style.left=s.x+'px';el.style.top=s.y+'px';el.style.width=len+'px';el.style.transformOrigin='0 50%';el.style.transform=`rotate(${ang}deg)`;diagram.appendChild(el);const lab=document.createElement('div');lab.className='beam-label';lab.textContent=b.label;lab.style.left=(s.x+e.x)/2+'px';lab.style.top=(s.y+e.y)/2+'px';diagram.appendChild(lab);});
+const ridge=document.createElement('div');ridge.className='ridge-beam';ridge.style.left='250px';ridge.style.top='200px';ridge.style.width='200px';ridge.style.transform='rotate(20deg)';diagram.appendChild(ridge);const ridgeLab=document.createElement('div');ridgeLab.className='beam-label';ridgeLab.textContent='Ridge Beam (26.9\' total)';ridgeLab.style.left='350px';ridgeLab.style.top='180px';ridgeLab.style.color='#8e44ad';diagram.appendChild(ridgeLab);const wall=document.createElement('div');wall.className='load-bearing-wall';wall.style.left='50px';wall.style.top='400px';wall.style.width='300px';diagram.appendChild(wall);const wallLab=document.createElement('div');wallLab.className='beam-label';wallLab.textContent='Load Bearing Wall at Ridge';wallLab.style.left='200px';wallLab.style.top='380px';wallLab.style.color='#2c3e50';diagram.appendChild(wallLab);const sampleRafters=[{start:{x:50,y:400},end:{x:50,y:310}},{start:{x:50,y:400},end:{x:250,y:200}},{start:{x:50,y:400},end:{x:470,y:300}}];sampleRafters.forEach(r=>{const el=document.createElement('div');el.className='rafter';const dx=r.end.x-r.start.x;const dy=r.end.y-r.start.y;const len=Math.sqrt(dx*dx+dy*dy);const ang=Math.atan2(dy,dx)*180/Math.PI;el.style.left=r.start.x+'px';el.style.top=r.start.y+'px';el.style.width=len+'px';el.style.transformOrigin='0 50%';el.style.transform=`rotate(${ang}deg)`;diagram.appendChild(el);});
+</script>
+</body>
+</html>

--- a/building-structure/w_beams.yml
+++ b/building-structure/w_beams.yml
@@ -1,0 +1,65 @@
+# W-flange beams between columns
+beams:
+  - id: WF_B1_B2
+    start_point: B1_top
+    end_point: B2_top
+    size: W8x15
+    loads:
+      uniform_plf: 520
+    connected_members: [B1, B2]
+  - id: WF_B2_B3
+    start_point: B2_top
+    end_point: B3_top
+    size: W8x15
+    loads:
+      uniform_plf: 680
+    connected_members: [B2, B3]
+  - id: WF_B3_B4
+    start_point: B3_top
+    end_point: B4_top
+    size: W10x17
+    loads:
+      uniform_plf: 1840
+    connected_members: [B3, B4]
+  - id: WF_B4_B5
+    start_point: B4_top
+    end_point: B5_top
+    size: W10x22
+    loads:
+      uniform_plf: 2580
+    connected_members: [B4, B5]
+  - id: WF_B5_B6
+    start_point: B5_top
+    end_point: B6_top
+    size: W8x18
+    loads:
+      uniform_plf: 2850
+    connected_members: [B5, B6]
+  - id: WF_B6_B7
+    start_point: B6_top
+    end_point: B7_top
+    size: W8x18
+    loads:
+      uniform_plf: 1120
+    connected_members: [B6, B7]
+  - id: WF_B7_B8
+    start_point: B7_top
+    end_point: B8_top
+    size: W10x17
+    loads:
+      uniform_plf: 1480
+    connected_members: [B7, B8]
+  - id: WF_B9_B10
+    start_point: B9_top
+    end_point: B10_top
+    size: LVL_5.5x14
+    loads:
+      uniform_plf: 1820
+    connected_members: [B9, B10]
+  - id: WF_B10_B11
+    start_point: B10_top
+    end_point: B11_top
+    size: LVL_5.5x14
+    loads:
+      uniform_plf: 1780
+    connected_members: [B10, B11]

--- a/report.py
+++ b/report.py
@@ -1,0 +1,45 @@
+import math
+import yaml
+from pathlib import Path
+
+DATA_DIR = Path('building-structure')
+
+with open(DATA_DIR / 'points.yml') as f:
+    points = yaml.safe_load(f)['points']
+
+def length(p1, p2):
+    a, b = points[p1], points[p2]
+    dx = a['x'] - b['x']
+    dy = a['y'] - b['y']
+    dz = a['z'] - b['z']
+    return math.sqrt(dx*dx + dy*dy + dz*dz)
+
+def summarize(file, key):
+    with open(DATA_DIR / file) as f:
+        data = yaml.safe_load(f)[key]
+    rows = []
+    for m in data:
+        start = m.get('start_point') or m.get('start')
+        end = m.get('end_point') or m.get('end')
+        if start and end:
+            span = length(start, end)
+        else:
+            span = None
+        rows.append((m['id'], span))
+    return rows
+
+sections = {
+    'hss_columns.yml': 'columns',
+    'w_beams.yml': 'beams',
+    'lvl_members.yml': 'lvl_members',
+    'ridge_and_walls.yml': 'components'
+}
+
+if __name__ == '__main__':
+    for file, key in sections.items():
+        print(f'\n{file}')
+        for mid, span in summarize(file, key):
+            if span is not None:
+                print(f"  {mid}: {span:.1f} in")
+            else:
+                print(f"  {mid}: n/a")

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+import yaml
+from jsonschema import validate
+
+BASE = Path(__file__).resolve().parent
+DATA_DIR = BASE / "building-structure"
+SCHEMA_DIR = DATA_DIR / "schemas"
+
+FILES = [
+    ("points.yml", "points.schema.json"),
+    ("hss_columns.yml", "hss_columns.schema.json"),
+]
+
+
+def main():
+    for data_name, schema_name in FILES:
+        data_path = DATA_DIR / data_name
+        schema_path = SCHEMA_DIR / schema_name
+        with data_path.open() as f:
+            data = yaml.safe_load(f)
+        with schema_path.open() as f:
+            schema = json.load(f)
+        validate(instance=data, schema=schema)
+        print(f"{data_name} passed schema validation")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add JSON Schema definitions for coordinate points and HSS columns
- provide `validate.py` to check YAML files against schemas
- document schema validation workflow in `building-structure/README.md`

## Testing
- `pip install jsonschema pyyaml`
- `python validate.py`
- `python report.py`


------
https://chatgpt.com/codex/tasks/task_e_688d000b0e1c83329514ed1287724e38